### PR TITLE
Fix test uploader for spectra files, fix MySQL metaparameter addition script

### DIFF
--- a/pyspecchio/edit_mysql_db.sql
+++ b/pyspecchio/edit_mysql_db.sql
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-"""
-Created on Wed Apr 18 17:08:38 2018
 
-@author: dvalters
-"""
+# Created on Wed Apr 18 17:08:38 2018
+
+# @author: dvalters
+
 # PICO SPECTRA METADATA
-"""
+# ADD METADATA VALUES
 INSERT INTO `specchio`.`attribute`(`name`, `category_id`, `default_storage_field`, `default_unit_id`, `description`)
  VALUES ('Dark', (select category_id from `specchio`.category where name ='General'),
  'string_val', (select unit_id from `specchio`.unit where short_name = ''), 
@@ -74,10 +74,10 @@ INSERT INTO `specchio`.`attribute`(`name`, `category_id`, `default_storage_field
  VALUES ('name', (select category_id from `specchio`.category where name ='General'),
  'string_val', (select unit_id from `specchio`.unit where short_name = ''), 
  'name');
-"""
+
 
 # Categories
-"""
+
 INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES ('26', 'Fluorescence', '');
 INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES ('27', 'GS', '');
 INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES ('28', 'Harvest', '');
@@ -91,9 +91,9 @@ INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES (
 INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES ('36', 'ResinExtracts', '');
 INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES ('37', 'Moisture', '');
 INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES ('38', 'pH', '');
-"""
+
 # Attributes METADATA FROM ANCIL DATA
-"""
+
 INSERT INTO `specchio`.`attribute` (`attribute_id`, `name`, `description`, `category_id`, `default_storage_field`, `cardinality`) VALUES ('402', 'Fertiliser_level', 'Fertiliser Level (GS)', '27', 'double_val', '1');
 INSERT INTO `specchio`.`attribute` (`attribute_id`, `name`, `description`, `category_id`, `default_storage_field`, `cardinality`) VALUES ('403', 'GS', 'GS', '27', 'double_val', '1');
 INSERT INTO `specchio`.`attribute` (`attribute_id`, `name`, `description`, `category_id`, `default_storage_field`, `cardinality`) VALUES ('404', 'Fertiliser_level', 'Fertiliser Level (Harvest)', '28', 'double_val', '1');
@@ -148,4 +148,4 @@ INSERT INTO `specchio`.`attribute` (`attribute_id`, `name`, `description`, `cate
 INSERT INTO `specchio`.`attribute` (`attribute_id`, `name`, `description`, `category_id`, `default_storage_field`) VALUES ('453', 'Moisture%g/g', 'Moisture%g/g', '37', 'double_val');
 INSERT INTO `specchio`.`attribute` (`attribute_id`, `name`, `description`, `category_id`, `default_storage_field`) VALUES ('454', 'Fertiliser_level', 'Fertiliser Level (pH)', '38', 'double_val');
 INSERT INTO `specchio`.`attribute` (`attribute_id`, `name`, `description`, `category_id`, `default_storage_field`) VALUES ('455', 'pH', 'pH', '38', 'double_val');
-"""
+

--- a/pyspecchio/edit_mysql_db.sql
+++ b/pyspecchio/edit_mysql_db.sql
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
+-- -*- coding: utf-8 -*-
 
-# Created on Wed Apr 18 17:08:38 2018
+-- Created on Wed Apr 18 17:08:38 2018
 
-# @author: dvalters
+-- @author: dvalters
 
-# PICO SPECTRA METADATA
-# ADD METADATA VALUES
+-- PICO SPECTRA METADATA
+-- ADD METADATA VALUES
 INSERT INTO `specchio`.`attribute`(`name`, `category_id`, `default_storage_field`, `default_unit_id`, `description`)
  VALUES ('Dark', (select category_id from `specchio`.category where name ='General'),
  'string_val', (select unit_id from `specchio`.unit where short_name = ''), 
@@ -76,7 +76,7 @@ INSERT INTO `specchio`.`attribute`(`name`, `category_id`, `default_storage_field
  'name');
 
 
-# Categories
+-- Categories
 
 INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES ('26', 'Fluorescence', '');
 INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES ('27', 'GS', '');
@@ -92,7 +92,7 @@ INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES (
 INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES ('37', 'Moisture', '');
 INSERT INTO `specchio`.`category` (`category_id`, `name`, `string_val`) VALUES ('38', 'pH', '');
 
-# Attributes METADATA FROM ANCIL DATA
+-- Attributes METADATA FROM ANCIL DATA
 
 INSERT INTO `specchio`.`attribute` (`attribute_id`, `name`, `description`, `category_id`, `default_storage_field`, `cardinality`) VALUES ('402', 'Fertiliser_level', 'Fertiliser Level (GS)', '27', 'double_val', '1');
 INSERT INTO `specchio`.`attribute` (`attribute_id`, `name`, `description`, `category_id`, `default_storage_field`, `cardinality`) VALUES ('403', 'GS', 'GS', '27', 'double_val', '1');

--- a/pyspecchio/specchio_db_interface.py
+++ b/pyspecchio/specchio_db_interface.py
@@ -400,12 +400,8 @@ class specchioDBinterface(object):
         for i in range(0, num_spectras -1):
             vector = spectra[i]  # 4 spectras from the PICO
             # TODO: not sure what the wavelengths are yet...use length 1...n
-            # Surely this 'w' should be the num of wavelngths, not the wavelength itself?
             for w in range(0, len(vector)):
-                spectra_array[i, w] = vector[w]
-                #print (num_spectras, num_wavelens, i, w, len(vector), spectra_array.shape)
-                # !! spectra_array[index, w] = vector[w]
-                # spectra_array[i, w] = vector[w]
+                spectra_array[i, w] = vector[w] 
             # Add wavelens
             spspectra_file_obj.addWvls(
                 [jp.java.lang.Float(x) for x in dummy_wavelens])

--- a/pyspecchio/specchio_db_interface.py
+++ b/pyspecchio/specchio_db_interface.py
@@ -397,7 +397,7 @@ class specchioDBinterface(object):
         # A numpy temporary holding array, dims of no of spectra x no of wvls
         spectra_array = np.zeros((num_spectras, num_wavelens))
 
-        for i in range(0, num_spectras -1):
+        for i in range(0, num_spectras):
             vector = spectra[i]  # 4 spectras from the PICO
             # TODO: not sure what the wavelengths are yet...use length 1...n
             for w in range(0, len(vector)):

--- a/pyspecchio/specchio_db_interface.py
+++ b/pyspecchio/specchio_db_interface.py
@@ -386,7 +386,8 @@ class specchioDBinterface(object):
         spectra = self.get_all_pico_spectra(spectrafile)
         metadata = self.get_all_pico_metadata(spectrafile)
         # Should be 4 for PICO file format
-        num_spectras = np.size(spectra)
+        num_spectras = np.size(spectra)  ## odd errors for the other sample PICO? (non USB, s2 one)
+        print(num_spectras)
         # TODO: remove hard coding
         num_wavelens = 2048
         # Should not be hard coded in final version, OK for now...
@@ -396,11 +397,15 @@ class specchioDBinterface(object):
         # A numpy temporary holding array, dims of no of spectra x no of wvls
         spectra_array = np.zeros((num_spectras, num_wavelens))
 
-        for i in range(0, num_spectras):
+        for i in range(0, num_spectras -1):
             vector = spectra[i]  # 4 spectras from the PICO
             # TODO: not sure what the wavelengths are yet...use length 1...n
-            for index, w in enumerate(vector):
-                spectra_array[index, w] = vector[w]
+            # Surely this 'w' should be the num of wavelngths, not the wavelength itself?
+            for w in range(0, len(vector)):
+                spectra_array[i, w] = vector[w]
+                #print (num_spectras, num_wavelens, i, w, len(vector), spectra_array.shape)
+                # !! spectra_array[index, w] = vector[w]
+                # spectra_array[i, w] = vector[w]
             # Add wavelens
             spspectra_file_obj.addWvls(
                 [jp.java.lang.Float(x) for x in dummy_wavelens])

--- a/pyspecchio/specchio_main.py
+++ b/pyspecchio/specchio_main.py
@@ -111,6 +111,7 @@ if args.test_spectra_mode:
     spectra_filepath = os.path.join(os.path.abspath(
             "../test/PICO_testdata/"), '')
     spectra_filename = "QEP1USB1_b000000_s000002_light.pico"
+    #spectra_filename = "QEPs2_b000000_s000002_light.pico"
     if args.campaign_name is None:
         campaign_name = "Test Campaign (spectra_file)"
     else:


### PR DESCRIPTION
Fixes an issue giving the wrong indices to index the spectra data on the uploader.

Adds a script for adding the metaparameters to the database. Run as: 

```
 mysql --user="username" --database="databasename" --password="yourpassword" < "filepath"
```

Where "filepath" is your quoted path to the `edit_mysql_db.sql` file in the `pyspecchio` source folder. 
